### PR TITLE
Feature/43 create tournament overview

### DIFF
--- a/backend/logic/api/entity/ml_simulator.py
+++ b/backend/logic/api/entity/ml_simulator.py
@@ -16,8 +16,9 @@ async def simulate_multiple_fake_ml_moves() -> None:
   await asyncio.sleep(15)
   
   games = {
-    2: ["d4", "d7", "c4", "e6", "Nc3", "Nf6", "Bg5", "Be7", "e3", "O-O", "Nf3", "h6", "Bh4", "b6", "cxd5", "Nxd5"], # d4, d5, c4
-    1: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "Nf6", "d3", "d6", "O-O", "O-O", "Nbd2", "a6", "Bb3", "Ba7"]
+    # 2: ["d4", "d7", "c4", "e6", "Nc3", "Nf6", "Bg5", "Be7", "e3", "O-O", "Nf3", "h6", "Bh4", "b6", "cxd5", "Nxd5"], # d4, d5, c4
+    1: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "Nf6", "d3", "d6", "O-O", "O-O", "Nbd2", "a6", "Bb3", "Ba7"],
+    2: ["a4", "d5", "Ra2", "Bh3", "a5", "b6", "gxh3", "bxa5", "Rxa5", "Nc6", "Bg2", "Nxa5", "Bxd5", "Qxd5", "Nf3", "Nc4", "Na3", "Rd8"]
   }
   
   async def send_moves(board_id, moves):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.18",
         "globals": "^15.14.0",
+        "react-router-dom": "^7.4.1",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
         "vite": "^6.1.0"
@@ -1115,6 +1116,12 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1500,6 +1507,15 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2326,6 +2342,46 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.4.1.tgz",
+      "integrity": "sha512-Vmizn9ZNzxfh3cumddqv3kLOKvc7AskUT0dC1prTabhiEi0U4A33LmkDOJ79tXaeSqCqMBXBU/ySX88W85+EUg==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.4.1.tgz",
+      "integrity": "sha512-L3/4tig0Lvs6m6THK0HRV4eHUdpx0dlJasgCxXKnavwhh4tKYgpuZk75HRYNoRKDyDWi9QgzGXsQ1oQSBlWpAA==",
+      "dev": true,
+      "dependencies": {
+        "react-router": "7.4.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2423,6 +2479,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2500,6 +2562,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
+    "react-router-dom": "^7.4.1",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",
     "vite": "^6.1.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import './App.css';
-import { useState } from 'react';
-import TableView from './pages/boardview/boardview';
+import TournamentView from './pages/tournamentview/tournamentview';
 
 /**
  * App Component
@@ -11,12 +10,9 @@ import TableView from './pages/boardview/boardview';
  */
 
 function App() {
-  // State to hold the list of chess moves (in algebraic notation)
-  const [moves, setMoves] = useState<string[]>([]);
-
   return (
     <div id="app">
-      <TableView moves={moves} setMoves={setMoves} />
+      <TournamentView/>
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import './App.css';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import BoardView from './pages/boardview/boardview';
 import TournamentView from './pages/tournamentview/tournamentview';
 
 /**
@@ -9,9 +11,13 @@ import TournamentView from './pages/tournamentview/tournamentview';
 
 function App() {
   return (
-    <div id="app">
-      <TournamentView/>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<TournamentView />} />
+        <Route path="/board/1" element={<BoardView id={1}/>} />
+        <Route path="/board/2" element={<BoardView id={2}/>} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,6 @@ import TournamentView from './pages/tournamentview/tournamentview';
  * App Component
  *
  * This is the main entry point of the React application.
- * It maintains the state of the chess moves and passes it
- * down to the `TableView` component.
  */
 
 function App() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,33 @@
 import './App.css';
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+
 import BoardView from './pages/boardview/boardview';
 import TournamentView from './pages/tournamentview/tournamentview';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 /**
  * App Component
  *
- * This is the main entry point of the React application.
+ * This is the root component of the React application.
+ * It sets up client-side routing using React Router.
+ *
+ * Routes:
+ * - `/`          → TournamentView (overview or menu for all boards)
+ * - `/board/1`   → BoardView for Board 1
+ * - `/board/2`   → BoardView for Board 2
+ *
+ * Additional board routes can be added here as needed.
  */
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
+        {/* Main tournament view */}
         <Route path="/" element={<TournamentView />} />
-        <Route path="/board/1" element={<BoardView id={1}/>} />
-        <Route path="/board/2" element={<BoardView id={2}/>} />
+
+        {/* Individual board views with IDs */}
+        <Route path="/board/1" element={<BoardView id={1} />} />
+        <Route path="/board/2" element={<BoardView id={2} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/camera/camera.tsx
+++ b/frontend/src/components/camera/camera.tsx
@@ -1,5 +1,18 @@
 import './camera.css';
 
+/**
+ * Camera Component
+ *
+ * Displays a live webcam feed for a given board using an image stream.
+ * The video stream is served from a backend endpoint and updated automatically by the browser.
+ *
+ * The stream URL is constructed using the board ID: `http://localhost:8000/video/{id}`
+ */
+
+/**
+ * Props for the Camera component
+ * - `id`: Unique identifier used to fetch the correct webcam stream for a specific board
+ */
 interface CameraProps {
   id: number;
 }

--- a/frontend/src/components/chessboard/chessboard.tsx
+++ b/frontend/src/components/chessboard/chessboard.tsx
@@ -8,10 +8,12 @@ import { useWebSocket } from "../../hooks/useWebSocket";
 /**
  * Chessboard Component
  *
- * This component renders an interactive chessboard and manages game state using the `chess.ts` library.
- * It consumes a WebSocket stream to receive and apply moves, and exposes its internal move list to parent components.
+ * This component renders a visual chessboard, maintains game state using `chess.ts`,
+ * listens to real-time move updates over WebSocket, and exposes its current move list
+ * to parent components via a forwarded ref.
  */
 
+// Represents a single piece's position and image
 interface Piece {
   image: string;
   x: number;
@@ -19,9 +21,9 @@ interface Piece {
 }
 
 /**
- * Converts a FEN string into an array of piece objects.
- * Each object includes image path and board coordinates.
- * Used to render pieces from the current game state.
+ * Converts a FEN string into an array of Piece objects.
+ * Maps chess notation characters to piece image paths and coordinates.
+ * The y-coordinate is flipped to align with visual board orientation.
  */
 function generatePositionFromFen(fen: string): Piece[] {
   const board = fen.split(" ")[0];
@@ -37,7 +39,7 @@ function generatePositionFromFen(fen: string): Piece[] {
 
   const pieces: Piece[] = [];
 
-  // Parse each row from top (8) to bottom (1)
+  // Parse the FEN rows (from top to bottom)
   for (let y = 0; y < rows.length; y++) {
     let x = 0;
     for (const char of rows[y]) {
@@ -55,13 +57,17 @@ function generatePositionFromFen(fen: string): Piece[] {
 }
 
 
-
+/**
+ * Props for Chessboard
+ * - `id`: Unique ID for the board, used in WebSocket connection
+ */
 interface ChessboardProps {
   id: number;
 }
 
 /**
- * Unique ID to identify the board
+ * Ref interface exposed by the Chessboard component.
+ * Allows parent components to retrieve the current move list.
  */
 export interface ChessboardHandle {
   getMoves: () => string[];
@@ -133,10 +139,9 @@ const Chessboard = forwardRef<ChessboardHandle, ChessboardProps>(({ id }, ref) =
 
   let board = [];
 
-  /**
-   * Generate the chessboard tiles and place pieces on them.
-   * The outer loop iterates through each row from 8 to 1 (top to bottom).
-   * The inner loop creates each tile and adds a piece if one exists at that coordinate.
+   /**
+   * Generates the full 8x8 chessboard as a grid of tiles.
+   * Each tile receives a piece image if one exists at its (x, y) coordinate.
    */
   for (let j = verticalAxis.length - 1; j >= 0; j--) {
     for (let i = 0; i < horizontalAxis.length; i++) {
@@ -154,7 +159,6 @@ const Chessboard = forwardRef<ChessboardHandle, ChessboardProps>(({ id }, ref) =
   }
 
   return (
-    
     <div id="chessboard">
       {board}
     </div>

--- a/frontend/src/components/chessboard/chessboard.tsx
+++ b/frontend/src/components/chessboard/chessboard.tsx
@@ -42,7 +42,7 @@ function generatePositionFromFen(fen: string): Piece[] {
     let x = 0;
     for (const char of rows[y]) {
       if (isNaN(Number(char))) {
-        const image = `assets/images/${pieceMap[char]}.png`;
+        const image = `/assets/images/${pieceMap[char]}.png`;
         pieces.push({ image, x, y: 7 - y }); // Flip y to match board orientation
         x++;
       } else {

--- a/frontend/src/components/pgn/pgn.tsx
+++ b/frontend/src/components/pgn/pgn.tsx
@@ -3,22 +3,26 @@ import "./pgn.css";
 /**
  * PGN Component
  *
- * This component displays a list of chess moves in standard PGN (Portable Game Notation) format.
- * It accepts an array of move strings and formats them into rows with turn numbers,
- * alternating white and black moves.
+ * Displays a list of chess moves in Portable Game Notation (PGN) format.
+ * It takes an array of move strings and formats them into rows,
+ * each representing a turn with a white and black move.
  */
 
+/**
+ * Props for the PGN component
+ * - `moves`: Array of algebraic notation moves (e.g., ["e4", "e5", "Nf3", "Nc6"])
+ */
 interface PGNProps {
-  moves: string[]; // Array of algebraic move notation strings
+  moves: string[];
 }
 
 function PGN({ moves }: PGNProps) {
   const rows = [];
 
   /**
-   * Group the moves into rows of white and black turns.
-   * Each pair of moves corresponds to one complete turn.
-   * If there's an odd number of moves, the last black move will be empty.
+   * Convert the flat array of moves into rows with turn numbers.
+   * Each row contains a `white` move and a `black` move.
+   * If the number of moves is odd, the last row's `black` cell will be empty.
    */
   for (let i = 0; i < moves.length; i += 2) {
     rows.push({

--- a/frontend/src/components/pgn/pgn.tsx
+++ b/frontend/src/components/pgn/pgn.tsx
@@ -20,7 +20,6 @@ function PGN({ moves }: PGNProps) {
    * Each pair of moves corresponds to one complete turn.
    * If there's an odd number of moves, the last black move will be empty.
    */
-
   for (let i = 0; i < moves.length; i += 2) {
     rows.push({
       turn: Math.floor(i / 2) + 1,

--- a/frontend/src/components/tile/tile.tsx
+++ b/frontend/src/components/tile/tile.tsx
@@ -1,20 +1,27 @@
-import "./Tile.css";
+import "./tile.css";
 
 /**
  * Tile Component
  *
- * This component represents an individual square on a chessboard.
- * It dynamically determines the tile color (black or white) based on the provided `number`,
- * which encodes both the row and column indices. If an `image` prop is passed, it displays
- * a chess piece on the tile using a background image.
+ * Represents a single square on the chessboard.
+ * The tile's color is determined by the `number` prop — even numbers create black tiles,
+ * and odd numbers create white tiles. This logic ensures a checkered board pattern.
+ *
+ * If an `image` prop is provided (usually a chess piece), it is rendered on the tile
+ * using a background image style.
  */
 
-interface Props {
-  number: number; // Used to determine tile color
-  image?: string; // Optional image URL for a chess piece
+/**
+ * Props for the Tile component
+ * - `number`: Determines tile color based on parity (even = black, odd = white)
+ * - `image`: Optional image URL for rendering a chess piece
+ */
+interface TileProps {
+  number: number; 
+  image?: string;
 }
 
-function Tile({ number, image }: Props) {
+function Tile({ number, image }: TileProps) {
    // Determine the tile color: even = black, odd = white
   if (number % 2 === 0) {
     return (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,9 +5,9 @@ import App from './App.tsx'
 
 
 /**
- * This file is responsible for rendering the React application.
- * It uses `createRoot` from React 18 to mount the App component inside the root element.
- * The `StrictMode` wrapper helps in identifying potential issues in the application.
+ * Application Entry Point
+ *
+ * This file is responsible for initializing and rendering the React application.
  */
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/boardview/boardview.tsx
+++ b/frontend/src/pages/boardview/boardview.tsx
@@ -1,20 +1,26 @@
+import './boardview.css';
+
+import Camera from '../../components/camera/camera';
 import Chessboard, { ChessboardHandle } from '../../components/chessboard/chessboard';
 import PGN from '../../components/pgn/pgn';
-import Camera from '../../components/camera/camera';
-import './boardview.css';
 import { useRef, useEffect, useState } from "react";
 import { NavLink } from 'react-router-dom';
 
 /**
-/**
  * BoardView Component
  *
- * This layout component arranges a single chessboard along with a PGN move list and camera feed.
- * It integrates child components and synchronizes the move history from the chessboard.
+ * This layout component arranges a single chessboard alongside:
+ * - A PGN move list (reflecting the current state of the game),
+ * - A camera feed (useful for physical board views or livestreams),
+ * - A navigation link back to the tournament overview.
+ *
+ * The component uses a `ref` to access the move history from the Chessboard component
+ * and updates the local `moves` state at regular intervals to keep the PGN list in sync.
  */
 
 /**
- * Unique ID to identify the board
+ * Props for BoardView
+ * - `id`: Unique identifier for the board, used to connect to the correct data stream (e.g., WebSocket or camera).
  */
 interface BoardViewProps {
   id: number;
@@ -24,10 +30,9 @@ function BoardView({ id }: BoardViewProps) {
   const boardRef = useRef<ChessboardHandle>(null); // Ref to access Chessboard's imperative handle (exposes getMoves method)
   const [moves, setMoves] = useState<string[]>([]); // State to hold the current list of moves in algebraic notation (SAN)
 
-  /**
-   * useEffect sets up a polling interval to fetch the latest moves
-   * from the chessboard via the exposed `getMoves()` method.
-   * This ensures the PGN view stays in sync with the board.
+   /**
+   * Sets up a polling interval to sync moves from the Chessboard component.
+   * Fetches move history every 500ms and updates the PGN view accordingly.
    */
   useEffect(() => {
     const interval = setInterval(() => {
@@ -37,7 +42,7 @@ function BoardView({ id }: BoardViewProps) {
       }
     }, 500); // Fetch moves every 500ms
 
-    return () => clearInterval(interval); // Clear the interval when component unmounts
+    return () => clearInterval(interval);  // Clean up on component unmount
   }, []);
 
   return (

--- a/frontend/src/pages/boardview/boardview.tsx
+++ b/frontend/src/pages/boardview/boardview.tsx
@@ -1,24 +1,44 @@
-import Chessboard from '../../components/chessboard/chessboard';
+import Chessboard, { ChessboardHandle } from '../../components/chessboard/chessboard';
 import PGN from '../../components/pgn/pgn';
 import Camera from '../../components/camera/camera';
 import './boardview.css';
+import { useRef, useEffect, useState } from "react";
 
+/**
 /**
  * BoardView Component
  *
- * This layout component arranges the chessboard and PGN move list side by side.
- * It passes move-related props to the corresponding child components:
- * - `Chessboard` handles the game state and piece interaction
- * - `PGN` displays the move history in a tabular format
+ * This layout component arranges a single chessboard along with a PGN move list and camera feed.
+ * It integrates child components and synchronizes the move history from the chessboard.
  */
 
+/**
+ * Unique ID to identify the board
+ */
 interface BoardViewProps {
-  moves: string[]; // Array of move strings (algebraic notation)
-  setMoves: React.Dispatch<React.SetStateAction<string[]>>; // Function to update the list of moves
   id: number;
 }
 
-function BoardView({ moves, setMoves, id }: BoardViewProps) {
+function BoardView({ id }: BoardViewProps) {
+  const boardRef = useRef<ChessboardHandle>(null); // Ref to access Chessboard's imperative handle (exposes getMoves method)
+  const [moves, setMoves] = useState<string[]>([]); // State to hold the current list of moves in algebraic notation (SAN)
+
+  /**
+   * useEffect sets up a polling interval to fetch the latest moves
+   * from the chessboard via the exposed `getMoves()` method.
+   * This ensures the PGN view stays in sync with the board.
+   */
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (boardRef.current) {
+        const newMoves = boardRef.current.getMoves();
+        setMoves(newMoves);
+      }
+    }, 500); // Fetch moves every 500ms
+
+    return () => clearInterval(interval); // Clear the interval when component unmounts
+  }, []);
+
   return (
     <div className="table-view">
       <div className='left-wrapper'>
@@ -30,7 +50,7 @@ function BoardView({ moves, setMoves, id }: BoardViewProps) {
           </div>
         </div>
         <div className="chessboard-wrapper">
-          <Chessboard setMoves={setMoves} id={id} />
+          <Chessboard ref={boardRef} id={id} />
         </div>
     </div>
   );

--- a/frontend/src/pages/boardview/boardview.tsx
+++ b/frontend/src/pages/boardview/boardview.tsx
@@ -15,21 +15,22 @@ import './boardview.css';
 interface BoardViewProps {
   moves: string[]; // Array of move strings (algebraic notation)
   setMoves: React.Dispatch<React.SetStateAction<string[]>>; // Function to update the list of moves
+  id: number;
 }
 
-function BoardView({ moves, setMoves }: BoardViewProps) {
+function BoardView({ moves, setMoves, id }: BoardViewProps) {
   return (
     <div className="table-view">
       <div className='left-wrapper'>
           <div className='camera-wrapper'>
-            <Camera id={1} />
+            <Camera id={id} />
           </div>
           <div className="pgn-wrapper">
             <PGN moves={moves} />
           </div>
         </div>
         <div className="chessboard-wrapper">
-          <Chessboard setMoves={setMoves} id={1} />
+          <Chessboard setMoves={setMoves} id={id} />
         </div>
     </div>
   );

--- a/frontend/src/pages/boardview/boardview.tsx
+++ b/frontend/src/pages/boardview/boardview.tsx
@@ -3,6 +3,7 @@ import PGN from '../../components/pgn/pgn';
 import Camera from '../../components/camera/camera';
 import './boardview.css';
 import { useRef, useEffect, useState } from "react";
+import { NavLink } from 'react-router-dom';
 
 /**
 /**
@@ -42,6 +43,10 @@ function BoardView({ id }: BoardViewProps) {
   return (
     <div className="table-view">
       <div className='left-wrapper'>
+        <NavLink
+            to="/">
+            Go back to tournament view
+          </NavLink>
           <div className='camera-wrapper'>
             <Camera id={id} />
           </div>

--- a/frontend/src/pages/tournamentview/tournamentview.tsx
+++ b/frontend/src/pages/tournamentview/tournamentview.tsx
@@ -1,5 +1,4 @@
 import './tournamentview.css';
-import { useState } from 'react';
 import BoardView from '../boardview/boardview';
 
 /**
@@ -9,14 +8,11 @@ import BoardView from '../boardview/boardview';
  * and manages the move history state. 
  */
 
-
 function TournamentView() {
-  // State to hold the list of chess moves (in algebraic notation)
-  const [moves, setMoves] = useState<string[]>([]);
 
   return (
     <div>
-      <BoardView moves={moves} setMoves={setMoves} id={1}/>
+      <BoardView id={1}/>
     </div>
   );
 }

--- a/frontend/src/pages/tournamentview/tournamentview.tsx
+++ b/frontend/src/pages/tournamentview/tournamentview.tsx
@@ -1,5 +1,5 @@
 import './tournamentview.css';
-import BoardView from '../boardview/boardview';
+import { NavLink } from 'react-router-dom';
 
 /**
  * TournamentView Component
@@ -9,10 +9,20 @@ import BoardView from '../boardview/boardview';
  */
 
 function TournamentView() {
-
   return (
     <div>
-      <BoardView id={1}/>
+      <h1>Tournament View</h1>
+      <div className="board-links">
+        <NavLink
+          to="/board/1">
+          Go to Board 1
+        </NavLink>
+        <br />
+        <NavLink
+          to="/board/2">
+          Go to Board 2
+        </NavLink>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/tournamentview/tournamentview.tsx
+++ b/frontend/src/pages/tournamentview/tournamentview.tsx
@@ -1,0 +1,24 @@
+import './tournamentview.css';
+import { useState } from 'react';
+import BoardView from '../boardview/boardview';
+
+/**
+ * TournamentView Component
+ * 
+ * This component serves as a container for rendering multiple chess boards
+ * and manages the move history state. 
+ */
+
+
+function TournamentView() {
+  // State to hold the list of chess moves (in algebraic notation)
+  const [moves, setMoves] = useState<string[]>([]);
+
+  return (
+    <div>
+      <BoardView moves={moves} setMoves={setMoves} id={1}/>
+    </div>
+  );
+}
+
+export default TournamentView;

--- a/frontend/src/pages/tournamentview/tournamentview.tsx
+++ b/frontend/src/pages/tournamentview/tournamentview.tsx
@@ -1,25 +1,29 @@
 import './tournamentview.css';
+
 import { NavLink } from 'react-router-dom';
 
 /**
  * TournamentView Component
  * 
- * This component serves as a container for rendering multiple chess boards
- * and manages the move history state. 
+ * This component serves as a navigation hub for multiple chess boards in a tournament.
+ * It renders links to individual board views using React Router's `NavLink` component.
+ * 
+ * Each link directs the user to a unique board route (e.g., `/board/1`, `/board/2`).
+ * This is a scalable layout for managing and switching between boards in a tournament.
  */
 
 function TournamentView() {
   return (
     <div>
       <h1>Tournament View</h1>
+
+      {/* Navigation links to individual boards */}
       <div className="board-links">
-        <NavLink
-          to="/board/1">
+        <NavLink to="/board/1">
           Go to Board 1
         </NavLink>
         <br />
-        <NavLink
-          to="/board/2">
+        <NavLink to="/board/2">
           Go to Board 2
         </NavLink>
       </div>


### PR DESCRIPTION
The frontend now display multiple boards. A simple tournament view is created to display all available boards. The number of boards is now hardcoded. This represent only the functionality of the application.

- The application starts with the tournament view, where there are links to the boards
- If a board is selected, the user is redirected to the selected board view
- The board view includes a camera, chessboard representation and PGN notation
- The button "Go back to tournament view" redirects the user to the tournament overview, where the user is able to select another board
- Move history is saved within the specific board

Clocs #43 